### PR TITLE
Upgrade node-sass to v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var utils = require('loader-utils');
 var sass = require('node-sass');
 var path = require('path');
+var sassGraph = require('sass-graph');
 
 module.exports = function (content) {
     this.cacheable();
@@ -24,15 +25,28 @@ module.exports = function (content) {
 
     // output compressed by default
     opt.outputStyle = opt.outputStyle || 'compressed';
+    
+    var loadPaths = opt.includePaths;
+    var markDependencies = function () {
+        try {
+            var graph = sassGraph.parseFile(this.resourcePath, {loadPaths: loadPaths});
+            graph.visitDescendents(this.resourcePath, function (imp) {
+                this.addDependency(imp);
+            }.bind(this));
+        } catch (err) {
+            this.emitError(err);
+        } 
+    }.bind(this);
 
     opt.success = function (result) {
-        result.stats.includedFiles.forEach(this.addDependency);
+        markDependencies();
         callback(null, result.css, result.map);
     }.bind(this);
 
     opt.error = function (err) {
+        markDependencies();
         callback({message: err.message + ' (' + err.line + ':' + err.column + ')'});
-    };
+    }.bind(this);
 
     sass.render(opt);
 };

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ module.exports = function (content) {
 
     // output compressed by default
     opt.outputStyle = opt.outputStyle || 'compressed';
-    opt.stats = {};
     
     var loadPaths = opt.includePaths;
     var markDependencies = function () {
@@ -39,14 +38,13 @@ module.exports = function (content) {
         } 
     }.bind(this);
 
-    opt.success = function (css) {
+    opt.success = function (result) {
         markDependencies();
-        callback(null, css);
+        callback(null, result.css, result.map);
     }.bind(this);
 
     opt.error = function (err) {
         markDependencies();
-        this.emitError(err);
         callback(err);
     }.bind(this);
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "^0.2.5",
-    "node-sass": "^2.0.0-beta"
+    "node-sass": "^2.0.0-beta",
+    "sass-graph": "git+https://github.com/lox/sass-graph.git#3a17328"
   },
   "devDependencies": {
     "mocha": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "^0.2.5",
-    "node-sass": "^2.0.0-beta",
-    "sass-graph": "git+https://github.com/lox/sass-graph.git#3a17328"
+    "node-sass": "^2.0.0-beta"
   },
   "devDependencies": {
     "mocha": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-loader",
-  "version": "0.4.0",
+  "version": "0.4.0-beta.1",
   "description": "SASS loader for Webpack",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-loader",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "SASS loader for Webpack",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "^0.2.5",
-    "node-sass": "^1.2.2",
+    "node-sass": "^2.0.0-beta",
     "sass-graph": "git+https://github.com/lox/sass-graph.git#3a17328"
   },
   "devDependencies": {

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -21,7 +21,7 @@ var path = require('path');
                 includePaths: [
                     path.join(__dirname, ext, 'another')
                 ]
-            })
+            }).css;
         })
         .forEach(function (content, index) {
             fs.writeFileSync(files[index].replace(new RegExp('\\.' + ext + '$', 'gi'), '.css'), content, 'utf8');


### PR DESCRIPTION
I ran into some [issues](https://github.com/interactivethings/catalyst/issues/3) with advanced SASS features, which could be fixed by upgrading node-sass to `v2.0.0-beta`. v2 also has some nice features like a list of included files which can directly be used to mark dependencies, and more accurate errors.

A couple of things I'm not really sure about:

- Dependencies also have been marked when an error occurred. I removed this, since I don't think it's needed (and node-sass doesn't include a file list on error) but I couldn't really find any documentation for it.
- I noticed the tests don't really seem to test the loader but just node-sass.

I've bumped the version to `0.4.0-beta.1`, to indicate that we're still relying on the node-sass beta.