### PR TITLE
Makes it clear how to require .sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,25 @@ module.exports = {
 };
 ```
 
-Then you only need to write: `require("./file.scss")`. See [`node-sass`](https://github.com/andrew/node-sass) for the available options.
+Then you only need to write: `require("./file.scss")`. 
+
+For requiring `.sass` files, add `indentedSyntax=sass` as a loader option:
+
+``` javascript
+module.exports = {
+  module: {
+    loaders: [
+      {
+        test: /\.scss$/,
+        // Passing indentedSyntax query param to node-sass
+        loader: "style!css!sass?indentedSyntax=sass
+      }
+    ]
+  }
+};
+```
+
+See [`node-sass`](https://github.com/andrew/node-sass) for the available options.
 
 ## Install
 


### PR DESCRIPTION
It was unclear how to `require(something.sass)` (had to search through  `test` : https://github.com/jtangelder/sass-loader/blob/51485cd5245d001dce8c575a0c408c59969fbc67/test/index.test.js#L26 )

 This commit clarifies it in the README.