### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "^0.2.5",
-    "node-sass": "^2.0.0-beta",
+    "node-sass": "^2.0.1",
     "sass-graph": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I experienced a lot of problem caused by `node-sass-binaries` D/L path not set correctly. (https://github.com/sass/node-sass/issues/665)
This issue is solved on v2.0.1.