### PR TITLE
Delete `result.map` when result.map is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ module.exports = function (content) {
             // the first source is 'stdin' according to libsass because we've used the data input
             // now let's override that value with the correct relative path
             result.map.sources[0] = path.relative(this.options.output.path, utils.getRemainingRequest(this));
+        } else {
+            result.map = null
         }
 
         callback(null, result.css, result.map);


### PR DESCRIPTION
Since a source map like `{}` is not a valid source map. This causes webpack builds to fail with `Error: "version" is a required argument.`.

This should fix passy/autoprefixer-loader/issues/17.