### PR TITLE
BC break: node-sass V3 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function (content) {
         }
     }.bind(this);
 
-    opt.success = function (result) {
+    var successCallback = function (result) {
         markDependencies();
 
         if (result.map && result.map !== '{}') {
@@ -66,10 +66,12 @@ module.exports = function (content) {
         callback(null, result.css, result.map);
     }.bind(this);
 
-    opt.error = function (err) {
+    var errorCallback = function (err) {
         markDependencies();
         callback({message: err.message + ' (' + err.line + ':' + err.column + ')'});
     }.bind(this);
 
-    sass.render(opt);
+    sass.render(opt, function( err, result ){
+        err  ? errorCallback(err) : successCallback(result);
+    });
 };


### PR DESCRIPTION
Node-sass v3 is in preview, and they changed the way success/error callbacks work. This change mirrors the new structure as explained at https://github.com/sass/node-sass/releases/tag/v3.0.0-pre but it is not backwards compatible, so will require a version bump in sass-loader (along with the change in package.json requirements for node-sass to allow V3 whenever that comes out).