### PR TITLE
updated node-sass to 3.0.0-pre

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,13 @@ module.exports = function (content) {
         }
     }.bind(this);
 
-    opt.success = function (result) {
+    sass.render(opt, function(err, result) {
+        if(err) {
+            markDependencies();
+            callback({message: err.message + ' (' + err.line + ':' + err.column + ')'});
+            return;
+        }
+
         markDependencies();
 
         if (result.map && result.map !== '{}') {
@@ -64,12 +70,5 @@ module.exports = function (content) {
         }
 
         callback(null, result.css, result.map);
-    }.bind(this);
-
-    opt.error = function (err) {
-        markDependencies();
-        callback({message: err.message + ' (' + err.line + ':' + err.column + ')'});
-    }.bind(this);
-
-    sass.render(opt);
+    }.bind(this));
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "^0.2.5",
-    "node-sass": "^2.0.1",
+    "node-sass": "^3.0.0-pre",
     "sass-graph": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
There was some breaking changes in the upcoming 3.0.0 of `node-sass`. This upgrade is needed to run `iojs-1.5.1`.