### PR TITLE
Fix importing of .sass files from .scss and vice versa

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ module.exports = function (content) {
     var resourcePath = this.resourcePath;
     var fileExt;
     var opt;
+    var extensionMatcher = /\.(sass|scss)$/;
+    var contextMatch;
+    var extension;
 
     /**
      * Enhances the sass error with additional information about what actually went wrong.
@@ -66,27 +69,30 @@ module.exports = function (content) {
     function getWebpackImporter() {
         if (isSync) {
             return function syncWebpackImporter(url, context) {
-
-                url = urlToRequest(url);
+                url = urlToRequest(url, context);
                 context = normalizeContext(context);
 
                 return syncResolve(self, url, context);
             };
         }
         return function asyncWebpackImporter(url, context, done) {
-
-            url = urlToRequest(url);
+            url = urlToRequest(url, context);
             context = normalizeContext(context);
 
             asyncResolve(self, url, context, done);
         };
     }
 
-    function urlToRequest(url) {
-        // Add file extension if it's not present already
-        if (url.slice(-fileExt.length) !== fileExt) {
-            url = url + fileExt;
+    function urlToRequest(url, context) {
+        contextMatch = context.match(extensionMatcher);
+
+        // Add sass/scss extension if it is missing
+        // The extension is inherited from importing resource or the default is used
+        if (!url.match(extensionMatcher)) {
+            extension = contextMatch && contextMatch[0] || fileExt
+            url = url + extension;
         }
+
         return utils.urlToRequest(url, opt.root);
     }
 


### PR DESCRIPTION
We are using bootstrap-sass (which has `.scss` files) but all our CSS is written in `.sass`.

In version 0.4.2 this worked without a problem. But newer versions of sass-loader add the extension to the file automatically based on configuration (`indentedSyntax`). That means this does not work:
```sass
// app.sass
@import node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables.scss
```
Currently the loader tries to load file `node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables.scss.sass`.

With this simple change we introduce "inheritance" of the extension. That means if we import a file with explicit extension all files imported from it will inherit its extension even when there is none specified in the import statement.

Otherwise the behavior remains unchanged. This should not be a backwards incompatible change.

Let me know if this is OK, I'll add some test then :wink: 