### PR TITLE
Update node-sass dependency to ^3 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "J. Tangelder",
   "license": "MIT",
   "peerDependencies": {
-    "node-sass": "^3.0.0-beta.4"
+    "node-sass": "^3.1.0"
   },
   "dependencies": {
     "loader-utils": "^0.2.5"
@@ -33,7 +33,7 @@
     "enhanced-require": "^0.5.0-beta6",
     "extract-text-webpack-plugin": "^0.3.8",
     "mocha": "^2.0.1",
-    "node-sass": "^3.0.0-alpha.0",
+    "node-sass": "^3.1.0",
     "raw-loader": "^0.5.1",
     "should": "^5.0.1",
     "style-loader": "^0.8.3",


### PR DESCRIPTION
This PR updates the node-sass dependencies to ^3 stable.

Fixes #65.
Fixes #70.
Fixes #71.
Fixes #77.
