### PR TITLE
Temporarily use require('node-sass').renderSync to avoid node-sass hang where the same file is imported by multiple other files

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var sass = require('node-sass');
 var path = require('path');
 var os = require('os');
 var fs = require('fs');
+var deasync = require('deasync');
 
 // A typical sass error looks like this
 var SassError = {
@@ -23,7 +24,8 @@ var resolveError = /Cannot resolve/;
  * @returns {*}
  */
 module.exports = function (content) {
-    var isSync = true;
+    var callback = this.async();
+    var isSync = typeof callback !== 'function';
     var self = this;
     var resourcePath = this.resourcePath;
     var extensionMatcher = /\.(sass|scss)$/;
@@ -66,19 +68,17 @@ module.exports = function (content) {
      * @returns {function}
      */
     function getWebpackImporter() {
-        if (isSync) {
-            return function syncWebpackImporter(url, context) {
-                url = urlToRequest(url, context);
-                context = normalizeContext(context);
-
-                return syncResolve(self, url, context);
-            };
-        }
-        return function asyncWebpackImporter(url, context, done) {
+        return function syncWebpackImporter(url, context) {
             url = urlToRequest(url, context);
             context = normalizeContext(context);
+            var result = null;
 
-            asyncResolve(self, url, context, done);
+            asyncResolve(self, url, context, function(ret) {
+                result = ret;
+            });
+
+            deasync.loopWhile(function() {return result === null;});
+            return result;
         };
     }
 
@@ -136,47 +136,26 @@ module.exports = function (content) {
     opt.importer = getWebpackImporter();
 
 
-    // start the actual rendering
-    if (isSync) {
-        var result;
-        try {
-            result = sass.renderSync(opt);
-        } catch (err) {
-            formatSassError(err);
-            throw err;
-        }
-
-        if (result.map && result.map !== '{}') {
-            result.map = JSON.parse(result.map);
-            result.map.file = resourcePath;
-            // The first source is 'stdin' according to libsass because we've used the data input
-            // Now let's override that value with the correct relative path
-            result.map.sources[0] = path.relative(self.options.output.path, resourcePath);
-        } else {
-            result.map = null;
-        }
-
-        return [result.css.toString(), result.map];
+    // do the actual rendering
+    var result;
+    try {
+        result = sass.renderSync(opt);
+    } catch (err) {
+        formatSassError(err);
+        throw err;
     }
-    sass.render(opt, function onRender(err, result) {
-        if (err) {
-            formatSassError(err);
-            callback(err);
-            return;
-        }
 
-        if (result.map && result.map !== '{}') {
-            result.map = JSON.parse(result.map);
-            result.map.file = resourcePath;
-            // The first source is 'stdin' according to libsass because we've used the data input
-            // Now let's override that value with the correct relative path
-            result.map.sources[0] = path.relative(self.options.output.path, resourcePath);
-        } else {
-            result.map = null;
-        }
+    if (result.map && result.map !== '{}') {
+        result.map = JSON.parse(result.map);
+        result.map.file = resourcePath;
+        // The first source is 'stdin' according to libsass because we've used the data input
+        // Now let's override that value with the correct relative path
+        result.map.sources[0] = path.relative(self.options.output.path, resourcePath);
+    } else {
+        result.map = null;
+    }
 
-        callback(null, result.css.toString(), result.map);
-    });
+    callback(null, result.css.toString(), result.map);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-loader",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Sass loader for webpack",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-loader",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Sass loader for webpack",
   "main": "index.js",
   "scripts": {
@@ -26,6 +26,7 @@
     "node-sass": "^3.1.0"
   },
   "dependencies": {
+    "deasync": "0.1.0",
     "loader-utils": "^0.2.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This isn't a good long term solution but it fixes the problem and allows sass files to be compiled properly (if more slowly) by webpack until the bug in node-sass is fixed.