### PR TITLE
can not import module which locates at includePaths directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ module.exports = {
 
 If you want to view the original Sass files inside Chrome and even edit it,  [there's a good blog post](https://medium.com/@toolmantim/getting-started-with-css-sourcemaps-and-in-browser-sass-editing-b4daab987fb0). Checkout [test/sourceMap](https://github.com/jtangelder/sass-loader/tree/master/test) for a running example. Make sure to serve the content with an HTTP server.
 
+## Contribution  
+  
+### How to run test  
+```bash  
+  mkdir -p test/node_modules/ && touch test/node_modules/some-module.s{a,c}ss && touch test/node_modules/underscore.s{a,c}ss
+  npm test
+```
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = function (content) {
     // add result files to loader
     function addNodeSassResult2WebpackDep(loader, result) {
       if (!loader || !result || !result.stats
-          || !result.stats.includedFiles || 1 > result.stats.includedFiles) {
+          || !result.stats.includedFiles || 1 > result.stats.includedFiles.length) {
         return;
       }
 

--- a/test/another/sass/_underscoreIncPathStyle.sass
+++ b/test/another/sass/_underscoreIncPathStyle.sass
@@ -1,0 +1,1 @@
+// just empty for includePaths feature

--- a/test/another/sass/incPathsStyle.sass
+++ b/test/another/sass/incPathsStyle.sass
@@ -1,0 +1,1 @@
+// just empty for includePaths feature

--- a/test/another/scss/_underscoreIncPathStyle.scss
+++ b/test/another/scss/_underscoreIncPathStyle.scss
@@ -1,0 +1,1 @@
+// just empty for includePaths feature

--- a/test/another/scss/incPathsStyle.scss
+++ b/test/another/scss/incPathsStyle.scss
@@ -1,0 +1,1 @@
+// just empty for includePaths feature

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,6 +38,9 @@ describe('sass-loader', function () {
         testSync('should resolve imports from other language style correctly (sync)', 'import-other-style');
         testAsync('should resolve imports from other language style correctly (async)', 'import-other-style');
 
+        // test for includepath not under context
+        testSync('should resolve imports from another directory declared by includePaths correctly(sync)', 'import-include-paths');
+        testAsync('should resolve imports from another directory declared by includePaths correctly(async)', 'import-include-paths');
     });
 
     describe('errors', function () {
@@ -72,7 +75,7 @@ describe('sass-loader', function () {
             } catch (err) {
                 // check for file excerpt
                 err.message.should.match(/@import "does-not-exist";/);
-                err.message.should.match(/File to import not found or unreadable: \.\/_does-not-exist\.scss/);
+                err.message.should.match(/File to import not found or unreadable: does-not-exist\.scss/);
                 err.message.should.match(/\(line 1, column 9\)/);
                 err.message.indexOf(pathToErrorFileNotFound).should.not.equal(-1);
             }
@@ -140,6 +143,6 @@ function testSync(name, id) {
 function pathToSassFile(ext, id) {
     return 'raw!' +
         pathToSassLoader + '?' +
-        (ext === 'sass'? '&indentedSyntax' : '') + '!' +
+        (ext === 'sass'? '&indentedSyntax&' : '') + 'includePaths[]=' + path.join(__dirname, 'another', ext) + '!' +
         path.join(__dirname, ext, id + '.' + ext);
 }

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -36,7 +36,8 @@ var filesWithTildeImports = [
             css = sass.renderSync({
                 file: fileName,
                 includePaths: [
-                    path.join(__dirname, ext, 'another')
+                    path.join(__dirname, ext, 'another'),
+                    path.join(__dirname, 'another', ext)
                 ]
             }).css;
 

--- a/test/sass/import-include-paths.sass
+++ b/test/sass/import-include-paths.sass
@@ -1,0 +1,2 @@
+@import incPathsStyle
+@import underscoreIncPathStyle

--- a/test/scss/import-include-paths.scss
+++ b/test/scss/import-include-paths.scss
@@ -1,0 +1,2 @@
+@import "incPathsStyle";
+@import "underscoreIncPathStyle";


### PR DESCRIPTION
### bug or feature:
  can not import modules locates at **includePaths" option.

### solution
  when webpack resolver fails to resolve modules, pass import as-is to node-sass instead of import as-is prefixed with underscore. 

Thus the loader can resolve modules using webpack resolver and from libsass includePaths.

see issue #110  #98  for more details.