### PR TITLE
Keep watching files imported in sass also when they have errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,6 +155,9 @@ module.exports = function (content) {
             addIncludedFilesToWebpack(cachedIncludedFiles);
             return result.css.toString();
         } catch (err) {
+            if (err.file) {
+                cachedIncludedFiles.push(err.file);
+            }
             addIncludedFilesToWebpack(cachedIncludedFiles);
             formatSassError(err);
             throw err;
@@ -162,6 +165,10 @@ module.exports = function (content) {
     }
     sass.render(opt, function onRender(err, result) {
         if (err) {
+            console.log(err);
+            if (err.file) {
+                cachedIncludedFiles.push(err.file);
+            }
             addIncludedFilesToWebpack(cachedIncludedFiles);
             formatSassError(err);
             callback(err);

--- a/index.js
+++ b/index.js
@@ -165,7 +165,6 @@ module.exports = function (content) {
     }
     sass.render(opt, function onRender(err, result) {
         if (err) {
-            console.log(err);
             if (err.file) {
                 cachedIncludedFiles.push(err.file);
             }


### PR DESCRIPTION
If you build following codes

```js
require('./style.scss');
```

```scss
// style.scss
@import "external";
```

```scss
// _external.scss
.red {
  color: red;
}
```

and change `_external.scss` with error such as syntax error like

```scss
// _external.scss (missing closing brace)
.red {
  color: red;
```

then Webpack will **not** recompile the scss files.

And If you build `style.scss` importing `_external.scss` missing closing brace firstly and modify `_external.scss`, Webpack will also not recompile them.

This PR fixes them.
