### PR TITLE
Node 4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "file-loader": "^0.8.4",
     "jshint": "^2.8.0",
     "mocha": "^2.0.1",
-    "node-sass": "^3.2.0",
+    "node-sass": "^3.3.0",
     "raw-loader": "^0.5.1",
     "should": "^7.0.2",
     "style-loader": "^0.12.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "J. Tangelder",
   "license": "MIT",
   "peerDependencies": {
-    "node-sass": "^3.2.0"
+    "node-sass": "^3.3.0"
   },
   "dependencies": {
     "async": "^1.4.0",


### PR DESCRIPTION
Currently, sass-loader does not support Node 4 due to [an issue of node-sass](
https://github.com/sass/node-sass/issues/1122)

However, Node 4 compatibility has been added in the release of [v3.3.3](
https://github.com/sass/node-sass/releases/tag/v3.3.3)
