### PR TITLE
Fix loader query not overriding webpack config

### DIFF
--- a/index.js
+++ b/index.js
@@ -381,5 +381,5 @@ function getLoaderConfig(loaderContext) {
 
     delete query.config;
 
-    return assign(query, config);
+    return assign({}, config, query);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,6 +27,31 @@ describe('sass-loader', function () {
 
     });
 
+    describe('config', function () {
+
+        it('should override sassLoader config with loader query', function () {
+            var expectedCss = readCss('sass', 'language');
+            var sassFile = pathToSassFile('sass', 'language');
+            var webpackConfig = Object.assign({}, {
+                entry: sassFile,
+                sassLoader: {
+                    // Incorrect setting here should be overridden by loader query string given by
+                    // pathToSassFile()
+                    indentedSyntax: false
+                }
+            });
+            var enhancedReq;
+            var actualCss;
+
+            enhancedReq = enhancedReqFactory(module, webpackConfig);
+            actualCss = enhancedReq(webpackConfig.entry);
+
+            fs.writeFileSync(__dirname + '/output/should override sassLoader config with loader query.sass.sync.css', actualCss, 'utf8');
+            actualCss.should.eql(expectedCss);
+        });
+
+    });
+
     describe('imports', function () {
 
         testSync('should resolve imports correctly (sync)', 'imports');


### PR DESCRIPTION
@jtangelder I noticed the merging of config here didn't match the comment. This fixes it and adds a test. There wasn't a similar kind of test so... this is probably not how you'd write the test, but the new test *does* fail without the change to `index.js`.

