### PR TITLE
Provide loader context

### DIFF
--- a/index.js
+++ b/index.js
@@ -381,5 +381,5 @@ function getLoaderConfig(loaderContext) {
 
     delete query.config;
 
-    return assign({}, config, query);
+    return assign({ loaderContext: loaderContext }, config, query);
 }


### PR DESCRIPTION
@jtangelder This allows an importer to really do cool stuff like evaluate other files (use webpack's resolve mechanism) and add them to the build.