### PR TITLE
Feature - Global dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,6 +212,19 @@ module.exports = function (content) {
         return isSync ? content : callback(null, content);
     }
 
+    // Resolve global dependencies
+    if (sassOptions.globalIncludes) {
+        var globalIncludes = [].concat(sassOptions.globalIncludes);
+
+        // Convert imports list into sass compatible imports list
+        var globalIncludeImports = globalIncludes.map(function (include) {
+            return '@import "' + include + '";';
+        }).join('\n');
+
+        // Inject global dependencies as @imports in the top of the file
+        sassOptions.data = globalIncludeImports + sassOptions.data;
+    }
+
     // opt.outputStyle
     if (!sassOptions.outputStyle && this.minimize) {
         sassOptions.outputStyle = 'compressed';


### PR DESCRIPTION
# Global Dependencies

In the past I have setup applications to have a split, but mirrored file structure with JS components on one side, and their styles on another. That typically looks like;

- style/
  - all.scss
  - _variables.scss
  - modal
    - _modal.scss

- components/
  - all_components.js
  - modal
    - modal.js

- app/
  - app.js

In this model I have to resolves dependencies at three levels, all styles are @imported into 'all.scss', all componentes are included within 'all_components.js', and finally the app includes both 'all.scss', and 'all_components'. The trouble with this setup is that components aren't truely portable alone, i.e., I can't only include the 'modal.js' component and expect to receive all its functionality and style. My preference is to move to a model where that is possible, where I can include just 'modal' and not be concerned with the style the component requires. To solve that problem I've moved to a model where the component is organized with anything it needs to run. This includes tests, styles, and functionality. Taking the previous example,

- components/
  - _variables.scss
  - modal
    - modal.js
    - _modal.scss
    - tests/
      - modal-test.js

- app/
  - app.js
  - app.scss


The problem uncovered by this model is that 'modal' component has dependencies on the 'component-wide' _variables set. To include those, I would have to explicitly @import them for every new component I create. This would be repeated for any new 'component-wide' styles that were added later, like sprites, or layouts.

## Proposed solution

Create a configuration option to inject global dependencies at run time. This would solve my problem, and would help to keep components in this type of structure clean and maintainable.

This PR exposes a new configuration option 'globalIncludes' which will map to @import statements at the top of each processed file.

````
  sassLoader: {
    globalIncludes: [
      './_variables.scss',
      './_layout.scss'
    ]
  },
````

Example output

````
  # _modal.scss
  @import "./_variables.scss";
  @import "./_layout.scss";

  # _app.scss
  @import "./_variables.scss";
  @import "./_layout.scss";
````