### PR TITLE
Resolve file directory to resource path

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ module.exports = function (content) {
         if (fileContext === 'stdin') {
             fileContext = resourcePath;
         }
-        return path.dirname(fileContext);
+        return path.resolve(resourcePath, path.dirname(fileContext));
     }
 
     // When files have been imported via the includePaths-option, these files need to be


### PR DESCRIPTION
I have the following:

```
/* foo.scss */
@import './bar.scss';
/* ... */
```

```
/* bar.scss */
@import '~module/variables`;
/* ... */
```

```
/* ../../node_modules/module/_variables.scss */
/* ... */
```

I get the following error:

```
Error: 
@import '~module/variables';
       ^
      File to import not found or unreadable: ~module/variables/Users/jerrysu/foo/src/styles/
      in /Users/jerrysu/foo/src/styles/bar.scss (line 2, column 9)
    at options.error (/Users/jerrysu/foo/node_modules/node-sass/lib/index.js:277:32)
```

By modifying this code so that the directory context is resolved from the resource path, I no longer have these issues with these sort of dependencies.
