### PR TITLE
Make the `indentedSyntax` option a bit smarter.

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,14 @@ module.exports = function (content) {
     }
 
     // indentedSyntax is a boolean flag
-    sassOptions.indentedSyntax = Boolean(sassOptions.indentedSyntax);
+    var ext = path.extname(resourcePath);
+
+    // If we are compling sass and indentedSyntax isn't set, automatically set it.
+    if (ext && ext.toLowerCase() === '.sass' && sassOptions.indentedSyntax === undefined) {
+        sassOptions.indentedSyntax = true;
+    } else {
+        sassOptions.indentedSyntax = Boolean(sassOptions.indentedSyntax);
+    }
 
     // Allow passing custom importers to `node-sass`. Accepts `Function` or an array of `Function`s.
     sassOptions.importer = sassOptions.importer ? [].concat(sassOptions.importer) : [];


### PR DESCRIPTION
Instead of requiring loader config to set `sass?indentedSyntax` to compile whitespace significant Sass files, this change will automatically set it for you if necessary (when the current file is a SASS file).

This should make loader config a bit easier, because now you won’t need to have separate loaders for SCSS And SASS. For example:

```javascript
loaders = [{
   test: /\.scss$/,
   loader: ExtractTextPlugin.extract("style","css!sass")
}, {
  test: /\.sass$/,
  loader: ExtractTextPlugin.extract("style","css!sass?indentedSyntax")
}]

// BECOMES

loaders = [{
  test: /\.(scss|sass)$/,
  loader: ExtractTextPlugin.extract("style","css!sass")
}]
```

Additionally this has the side benefit of enabling SCSS <-> SASS interop in some advanced cases. Without this, it wasn’t possible for my [sprockets-directive-loader](https://github.com/timmfin/sprockets-directive-loader) project to work when a SASS file `//= require`ed a SCSS file. That’s because you would have had to set `indentedSyntax` on the loader, and that would have been “passed-on” (via `css?importLoaders=*`) to an SCSS file, causing its compile to fail.

So with this change, this will now work for a mix of SCSS and SASS files:

```javascript
loaders = [{
  test: /\.(scss|sass)$/,
  loader: ExtractTextPlugin.extract("style", "css?sourceMap&importLoaders=2!sprockets-directive!sass?sourceMap")
}]
```