### PR TITLE
Allow `data` to be passed as sass option

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ module.exports = function (content) {
 
     this.cacheable();
 
-    sassOptions.data = content;
+    sassOptions.data = sassOptions.data ? (sassOptions.data + '\n\n' + content) : content;
 
     // Skip empty files, otherwise it will stop webpack, see issue #21
     if (content.trim() === '') {


### PR DESCRIPTION
It's a very rare use case, but wanted to create a PR to find out if it's worthwhile making it to `sass-loader` too.

## Why?

* I used the `sassOptions.data` key to inject some dynamic Sass variables
* `node-sass` itself allows `data` to be passed in `sassOptions`

But...

`sass-loader` overwrites `sassOptions.data` which means I can't do the variable injection any more.

## Solution

Check if `sassOptions.data` is present first, and if yes, then prepend that before file content. Otherwise, just roll with the file content as normal.