### PR TITLE
Update README information

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,12 @@ module.exports = {
 webpack provides an [advanced mechanism to resolve files](http://webpack.github.io/docs/resolving.html). The sass-loader uses node-sass' custom importer feature to pass all queries to the webpack resolving engine. Thus you can import your Sass modules from `node_modules`. Just prepend them with a `~` to tell webpack that this is not a relative import:
 
 ```css
-@import "~bootstrap/less/bootstrap";
+@import "~bootstrap/css/bootstrap";
+```
+
+Alternatively, for bootstrap-sass:
+```css
+@import "~bootstrap-sass/assets/stylesheets/bootstrap";
 ```
 
 It's important to only prepend it with `~`, because `~/` resolves to the home directory. webpack needs to distinguish between `bootstrap` and `~bootstrap` because CSS- and Sass-files have no special syntax for importing relative files. Writing `@import "file"` is the same as `@import "./file";`


### PR DESCRIPTION
README had some leftovers from the `less` project. Updated to include documentation for both the `css` and `bootstrap-sass` options.