### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "J. Tangelder",
   "license": "MIT",
   "peerDependencies": {
-    "node-sass": "^3.5.3",
+    "node-sass": "^3.6.0",
     "webpack": "^1.12.6"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "J. Tangelder",
   "license": "MIT",
   "peerDependencies": {
-    "node-sass": "^3.4.2",
+    "node-sass": "^3.5.3",
     "webpack": "^1.12.6"
   },
   "dependencies": {
@@ -42,7 +42,6 @@
     "file-loader": "^0.8.4",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
-    "node-sass": "3.4.2",
     "raw-loader": "^0.5.1",
     "should": "^8.2.2",
     "style-loader": "^0.13.0",


### PR DESCRIPTION
Removed the devDependency because node-sass is already an peerDependency.
Also, the devDependencies had a strict version so the sass-loader didn't install the latest '3.x' dependency of node-sass.