### PR TITLE
Fix file path in source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ module.exports = function (content) {
         // deliberately overriding the sourceMap option
         // this value is (currently) ignored by libsass when using the data input instead of file input
         // however, it is still necessary for correct relative paths in result.map.sources
-        sassOptions.sourceMap = this.options.output.path + '/sass.map';
+        sassOptions.sourceMap = this.options.context + '/sass.map';
         sassOptions.omitSourceMapUrl = true;
 
         // If sourceMapContents option is not set, set it to true otherwise maps will be empty/null
@@ -278,7 +278,8 @@ module.exports = function (content) {
             result.map.file = resourcePath;
             // The first source is 'stdin' according to libsass because we've used the data input
             // Now let's override that value with the correct relative path
-            result.map.sources[0] = path.relative(self.options.output.path, resourcePath);
+            result.map.sources[0] = path.relative(self.options.context, resourcePath);
+            result.map.sourceRoot = path.relative(self.options.context, process.cwd());
         } else {
             result.map = null;
         }


### PR DESCRIPTION
There are currently two problems regarding source maps file path with this loader:

1. The loader depends on `self.options.output.path` to be set. If you don't set this property the relative urls in line 281 is calculated wrong. By using the context this problem does not exist anymore.
2. node-sass uses the directory in which the map file is created as root path. All source paths within the map are relative to this path. However, when webpack processes the sourcemaps it expects all paths to be relative to the webpack execution directory. To resolve all files correctly I added the `sourceRoot` property to express the relative path.

In combination with the suggested fix for the css-loader (https://github.com/webpack/css-loader/issues/280) this produces nice paths for source maps, that reflect the actual file structure within the project.