### PR TITLE
Use resoucePath for custom importers

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,13 @@ module.exports = function (content) {
     }
 
     // Allow passing custom importers to `node-sass`. Accepts `Function` or an array of `Function`s.
-    sassOptions.importer = sassOptions.importer ? [].concat(sassOptions.importer) : [];
+    sassOptions.importer = sassOptions.importer ? [].concat(sassOptions.importer).map(function(importer) {
+            return function(url, prev, done) {
+                return importer(url, prev === 'stdin' ? resourcePath : prev, done);
+            };
+        })
+        : []
+    ;
     sassOptions.importer.push(getWebpackImporter());
 
     // `node-sass` uses `includePaths` to resolve `@import` paths. Append the currently processed file.

--- a/test/tools/customImporter.js
+++ b/test/tools/customImporter.js
@@ -2,8 +2,9 @@
 
 var should = require('should');
 
-function customImporter(path) {
+function customImporter(path, prev) {
     path.should.equal('import-with-custom-logic');
+    prev.match(process.cwd() + '/test/(sass|scss)/custom-importer.(scss|sass)').should.not.equal(null);
     return customImporter.returnValue;
 }
 customImporter.returnValue = {


### PR DESCRIPTION
@jhnns, this should fix custom sass importers by passing `resourcePath` instead of `stdin` into the `prev` argument.

Fixes #234