### PR TITLE
fixes issue #275

### DIFF
--- a/index.js
+++ b/index.js
@@ -409,7 +409,7 @@ function getLoaderConfig(loaderContext) {
 function proxyCustomImporters(importer, resourcePath) {
     return [].concat(importer).map(function (importer) {
         return function (url, prev, done) {
-            return importer(url, prev === 'stdin' ? resourcePath : prev, done);
+            return importer.call(this, url, prev === 'stdin' ? resourcePath : prev, done);
         };
     });
 }

--- a/test/tools/customImporter.js
+++ b/test/tools/customImporter.js
@@ -5,6 +5,7 @@ var should = require('should');
 function customImporter(path, prev) {
     path.should.equal('import-with-custom-logic');
     prev.should.match(/(sass|scss)[/\\]custom-importer\.(scss|sass)/);
+    should(this).have.property('options');
     return customImporter.returnValue;
 }
 customImporter.returnValue = {


### PR DESCRIPTION
This is a simple change that fixes #275. Because the importer returned is now actually a proxy function, we needed to pass the context of the proxy to the real importer as some importers (such as `node-sass-import-once`) rely on this.