### PR TITLE
Pass on context provided by node-sass to proxied custom importer

### DIFF
--- a/index.js
+++ b/index.js
@@ -409,7 +409,7 @@ function getLoaderConfig(loaderContext) {
 function proxyCustomImporters(importer, resourcePath) {
     return [].concat(importer).map(function (importer) {
         return function (url, prev, done) {
-            return importer(url, prev === 'stdin' ? resourcePath : prev, done);
+            return importer.call(this, url, prev === 'stdin' ? resourcePath : prev, done).bind(self);
         };
     });
 }


### PR DESCRIPTION
node-sass [passes context](https://github.com/sass/node-sass/blob/b1744447f4cfb6f68e59c1e67bafd3b88ff9e04a/lib/index.js#L403) to custom importers. #267 broke this chain and this restores it. Discovered in response to [this](https://github.com/Updater/node-sass-json-importer/issues/34).