### PR TITLE
Fix sourcemap paths to use correct root

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ module.exports = function (content) {
             // The first source is 'stdin' according to libsass because we've used the data input
             // Now let's override that value with the correct relative path
             result.map.sources[0] = path.relative(self.options.context, resourcePath);
-            result.map.sourceRoot = path.relative(self.options.context, process.cwd());
+            result.map.sourceRoot = self.options.context;
         } else {
             result.map = null;
         }


### PR DESCRIPTION
Somehow `path.relative(self.options.context, process.cmd())` always seems to resolve to empty string when combining with `css-loader` leading to doubling the path to file: `src/styles/src/styles/global.scss`.

This makes debugging using Chrome DevTools and mapping to file system resource impossible for Sass files.
