### PR TITLE
Allow setting sourceRoot from config, defaulting to context

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ module.exports = function (content) {
             // The first source is 'stdin' according to libsass because we've used the data input
             // Now let's override that value with the correct relative path
             result.map.sources[0] = path.relative(self.options.context, resourcePath);
-            result.map.sourceRoot = path.relative(self.options.context, process.cwd());
+            result.map.sourceRoot = typeof sassOptions.sourceRoot === 'string' ? sassOptions.sourceRoot : self.options.context;
         } else {
             result.map = null;
         }


### PR DESCRIPTION
There's currently a few things wrong with the way sourcemaps are handled through the `sass-loader` -> `css-loader` -> `extract-text | style-loader` chain that causes paths to be wrong.

In my case, `sass-loader` shouldn't be setting `sourceRoot` to something I can't configure since I'm running the webpack build outside of the current working directory. `sourceRoot` should also just be the current context by default.