### PR TITLE
Changed Webpack 2 peer dependency to 2.2 rc ver

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "peerDependencies": {
     "node-sass": "^3.4.2 || ^4.0.0",
-    "webpack": "^1.12.6 || ^2.1.0-beta"
+    "webpack": "^1.12.6 || ^2.2.0-rc.0"
   },
   "dependencies": {
     "async": "^2.0.1",


### PR DESCRIPTION
Did this to resolve the unmet peer dependency error.
If you would like to retain support for 2.1 let me know and I'll amend.
I assumed you wouldn't as you're only supporting one version of webpack v1

Edit: 
Thinking about this a little more could someone explain to me why the current package.json doesn't work fine?
the jump from 2.1 to 2.2 is a minor release so surely ^2.1 should cover that.
I'm quite confused even though it does appear to have worked.
If what I have done isn't suitable please let me know and I shall close.

Thanks