### PR TITLE
Revert "Export instance of node-sass compiler"

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,8 +290,6 @@ module.exports = function (content) {
     });
 };
 
-module.exports.compiler = sass;
-
 /**
  * Tries to get an excerpt of the file where the error happened.
  * Uses err.line and err.column.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,8 +7,6 @@ var path = require('path');
 var webpack = require('webpack');
 var fs = require('fs');
 var enhancedReqFactory = require('enhanced-require');
-var nodeSass = require('node-sass');
-var sassLoader = require('../index.js');
 var customImporter = require('./tools/customImporter.js');
 var customFunctions = require('./tools/customFunctions.js');
 
@@ -48,14 +46,6 @@ describe('sass-loader', function () {
 
             fs.writeFileSync(__dirname + '/output/should override sassLoader config with loader query.sass.sync.css', actualCss, 'utf8');
             actualCss.should.eql(expectedCss);
-        });
-
-    });
-
-    describe('compiler instance', function () {
-
-        it('should export instance of node-sass compiler', function () {
-            sassLoader.compiler.should.eql(nodeSass);
         });
 
     });


### PR DESCRIPTION
Reverts jtangelder/sass-loader#317

This change is not necessary since we're using `peerDependencies`. The user is able to obtain the exact same instance via `require("node-sass")` anyway.