### PR TITLE
Fix incorrect source maps in certain cwds

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -54,14 +54,18 @@ function sassLoader(content) {
 
         if (result.map && result.map !== "{}") {
             result.map = JSON.parse(result.map);
-            result.map.file = resourcePath;
-            // The first source is 'stdin' according to libsass because we've used the data input
-            // Now let's override that value with the correct relative path
-            result.map.sources[0] = path.basename(resourcePath);
-            result.map.sourceRoot = path.dirname(resourcePath);
+            // result.map.file is an optional property that provides the output filename.
+            // Since we don't know the final filename in the webpack build chain yet, it makes no sense to have it.
+            delete result.map.file;
+            // The first source is 'stdin' according to node-sass because we've used the data input.
+            // Now let's override that value with the correct relative path.
+            // Since we specified options.sourceMap = path.join(process.cwd(), "/sass.map"); in normalizeOptions,
+            // we know that this path is relative to process.cwd(). This is how node-sass works.
+            result.map.sources[0] = path.relative(process.cwd(), resourcePath);
             // node-sass returns POSIX paths, that's why we need to transform them back to native paths.
             // This fixes an error on windows where the source-map module cannot resolve the source maps.
             // @see https://github.com/jtangelder/sass-loader/issues/366#issuecomment-279460722
+            result.map.sourceRoot = path.normalize(result.map.sourceRoot);
             result.map.sources = result.map.sources.map(path.normalize);
         } else {
             result.map = null;

--- a/lib/normalizeOptions.js
+++ b/lib/normalizeOptions.js
@@ -36,15 +36,24 @@ function normalizeOptions(loaderContext, content, webpackImporter) {
     // Not using the `this.sourceMap` flag because css source maps are different
     // @see https://github.com/webpack/css-loader/pull/40
     if (options.sourceMap) {
-        // deliberately overriding the sourceMap option
-        // this value is (currently) ignored by libsass when using the data input instead of file input
-        // however, it is still necessary for correct relative paths in result.map.sources.
-        options.sourceMap = loaderContext.options.context + "/sass.map";
-        options.omitSourceMapUrl = true;
-
-        // If sourceMapContents option is not set, set it to true otherwise maps will be empty/null
-        // when exported by webpack-extract-text-plugin.
+        // Deliberately overriding the sourceMap option here.
+        // node-sass won't produce source maps if the data option is used and options.sourceMap is not a string.
+        // In case it is a string, options.sourceMap should be a path where the source map is written.
+        // But since we're using the data option, the source map will not actually be written, but
+        // all paths in sourceMap.sources will be relative to that path.
+        // Pretty complicated... :(
+        options.sourceMap = path.join(process.cwd(), "/sass.map");
+        if ("sourceMapRoot" in options === false) {
+            options.sourceMapRoot = process.cwd();
+        }
+        if ("omitSourceMapUrl" in options === false) {
+            // The source map url doesn't make sense because we don't know the output path
+            // The css-loader will handle that for us
+            options.omitSourceMapUrl = true;
+        }
         if ("sourceMapContents" in options === false) {
+            // If sourceMapContents option is not set, set it to true otherwise maps will be empty/null
+            // when exported by webpack-extract-text-plugin.
             options.sourceMapContents = true;
         }
     }

--- a/test/bootstrapSass/webpack.config.js
+++ b/test/bootstrapSass/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
         path: path.resolve(__dirname, "../output"),
         filename: "bundle.bootstrap-sass.js"
     },
-    devtool: "inline-source-map",
+    devtool: "source-map",
     module: {
         rules: [{
             test: /\.scss$/,

--- a/test/tools/testLoader.js
+++ b/test/tools/testLoader.js
@@ -1,0 +1,14 @@
+"use strict";
+
+function testLoader(content, sourceMap) {
+    testLoader.content = content;
+    testLoader.sourceMap = sourceMap;
+
+    return "";
+}
+
+testLoader.content = "";
+testLoader.sourceMap = null;
+testLoader.filename = __filename;
+
+module.exports = testLoader;


### PR DESCRIPTION
All source map paths will be relative to process.cwd() from now on.
This removes also the last dependency on this.options.context.
node-sass source map options like sourceMapRoot, omitSourceMapUrl, sourceMapContents are now overridable.

https://github.com/jtangelder/sass-loader/pull/374#issuecomment-279572238